### PR TITLE
Unasigned onClick by props.

### DIFF
--- a/front/src/PopularEvents.js
+++ b/front/src/PopularEvents.js
@@ -30,6 +30,7 @@ class PopularEvents extends React.Component{
     let clickedEvent = this.state.popular_events.filter( event =>
         event.name === e.currentTarget.innerHTML
     );
+    // Code Review by @dnarvaez27: onClick function is not defined in certain cases (Check index.js (66))
     this.props.onClick(clickedEvent[0]);
   };
 


### PR DESCRIPTION
onClick prop is not assigned in index.js (66). Throws an error on click: [Function is not defined]